### PR TITLE
fix build error

### DIFF
--- a/redis.go
+++ b/redis.go
@@ -159,7 +159,7 @@ func (b broadcast) Leave(room string, socket socketio.Socket) error {
 }
 
 // Same as Broadcast
-func (b broadcast) Send(ignore socketio.Socket, room, message string, args []interface{}) error {
+func (b broadcast) Send(ignore socketio.Socket, room, message string, args ...interface{}) error {
   sockets := b.rooms[room]
   for id, s := range sockets {
     if ignore != nil && ignore.Id() == id {


### PR DESCRIPTION
When building:
Godeps/_workspace/src/github.com/kowabungappl/go-socket.io-redis/redis.go:96: cannot use b (type broadcast) as type socketio.BroadcastAdaptor in return argument:
    broadcast does not implement socketio.BroadcastAdaptor (wrong type for Send method)
        have Send(socketio.Socket, string, string, []interface {}) error
        want Send(socketio.Socket, string, string, ...interface {}) error
